### PR TITLE
different looking tasks under accordion on week view

### DIFF
--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -27,7 +27,7 @@ function sendDataToModal(id,desc,date,time,important,completed){
 
 //Function to display tasks in a box view
 function makeDescriptionHTML(task, taskDesc){
-  taskDesc += `<div class="toast show mb-3 mt-3" role="alert" aria-live="assertive" aria-atomic="true" style="cursor:pointer" onclick="sendDataToModal('${task.id}','${task.description}','${task.date}','${task.time}','${task.important}','${task.completed}')" data-bs-toggle="modal" data-bs-target="#edit_task_modal">`;
+  taskDesc += `<div class="toast show mb-3 mt-3 mx-3" role="alert" aria-live="assertive" aria-atomic="true" style="cursor:pointer" onclick="sendDataToModal('${task.id}','${task.description}','${task.date}','${task.time}','${task.important}','${task.completed}')" data-bs-toggle="modal" data-bs-target="#edit_task_modal">`;
       taskDesc += `<div class="toast-header justify-content-between">`;
           taskDesc += (task.important) ? `<strong><i class="bi bi-brightness-high-fill" style="color:red"></i></strong>` : `<span></span>`
           taskDesc += `<span class="fs-6">${task.date} | ${task.time}</span>`;

--- a/static/scripts/week-view.js
+++ b/static/scripts/week-view.js
@@ -27,3 +27,19 @@ const lastDay = new Date(firstDay.getTime() + 60*60*24*6*1000);
 
 //sets header to display the start and end day of the week
 document.querySelector(".current-week").innerHTML = month[firstDay.getMonth()] + " " + firstDay.getDate() + " - " + month[lastDay.getMonth()] + " " + lastDay.getDate();
+
+let task = {
+    "description": "Test",
+    "date": "2020-01-01",
+    "time": "12:00",
+    "important": true,
+    "completed": false,
+}
+let taskDesc = "";
+taskDesc = makeDescriptionHTML(task, taskDesc);
+$("#tasksForSunday").html(taskDesc);
+$("#tasksForSunday").append(taskDesc);
+$("#tasksForSunday").append(taskDesc);
+$("#tasksForSunday").append(taskDesc);
+$("#tasksForSunday").append(taskDesc);
+

--- a/templates/weekly.html
+++ b/templates/weekly.html
@@ -17,13 +17,7 @@
           </button>
         </h2>
         <div id="collapse{{day}}" class="accordion-collapse collapse" aria-labelledby="heading{{day}}" data-bs-parent="#accordionWeek">
-          <div class="accordion-body">
-            <div class="task">
-              <strong><i class="bi bi-brightness-high-fill" style="color:red"></i></strong>
-              <p class="task-header">yyyy-mm-dd | hh:mm</p>
-              <hr>
-              <p>Task description</p>
-            </div>
+          <div class="accordion-body d-flex justify-items-center align-items-center flex-wrap" id="tasksFor{{day}}">
           </div>
         </div>
       </div>


### PR DESCRIPTION
I made some changes to how an individual task would look inside the accordion. Below is a screenshot of how the PR will make it look like

![image](https://user-images.githubusercontent.com/33160137/154824618-d29c5986-5c66-4830-bea9-2b8344c04b0f.png)

For front-end purposes, I made a dummy task and used the same one multiple times, but that's what the front-end is about. I put it only under Sunday but the logic remains the same.