### PR TITLE
Sprint8

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -54,7 +54,7 @@ def login():
             # if user does not exist then:
             flash('Email not registered. Please sign up first.', category='error')
 
-    return render_template("login.html")
+    return render_template("login.html", email=email, password=password)
 
 
 @auth.route('/logout')

--- a/auth.py
+++ b/auth.py
@@ -97,14 +97,19 @@ def register():
 
         if(len(email)<1):
             flash('Email cannot be empty', category='error')
+
         elif(password1 != password2):
             flash('Password do not match', category='error')
+
         elif(len(password1)<8):
             flash('Password must be at least 8 characters long', category='error')
+
         elif(len(security_question)<1):
             flash('Security question cannot be empty', category='error')
+
         elif(len(security_answer)<1):
             flash('Security answer cannot be empty', category='error')
+
         else:
             try:
                 user_table = taskbook_db.get_table('user_cred')
@@ -113,6 +118,7 @@ def register():
                 if(user):
                     # flash alert and make them sign in again
                     flash('A user exists with that email address.', category='error')
+
                 else:
                     # if new user, then hash the password, insert to table and log them in
                     hashed_password = generate_password_hash(password1, method='sha256')
@@ -131,7 +137,7 @@ def register():
                 print(409, str(e))
                 return ("409 Bad Request:"+str(e), 409)
 
-    return render_template('register.html')
+    return render_template('register.html', email=email, password1=password1, password2=password2, security_question=security_question, security_answer=security_answer)
 
 
 @auth.route('/change_password', methods=['POST'])

--- a/static/scripts/dashboard.js
+++ b/static/scripts/dashboard.js
@@ -50,7 +50,7 @@ function displayDayTasks(key) {
                 time: "-",
                 description: "<h4 class='ms-3'>No tasks for today!<h4>",
             }
-            taskDesc = makeDescriptionHTML(task, taskDesc);
+            taskDesc = makeDescriptionHTML(task, taskDesc, false);
             document.getElementById("today_dashboard").innerHTML = taskDesc;
         }
 
@@ -64,3 +64,6 @@ let dateKey = viewDate.getFullYear() + '-' + appendZero(viewDate.getMonth() + 1)
 //displays tasks for today
 displayDayTasks(dateKey);
 displayProgress(dateKey)
+
+// hide the add task button on the dashboard because we want the modal to pop up on clicking the toast, not the button
+document.getElementById("add-task-button").style.display = "none";

--- a/static/scripts/day-view.js
+++ b/static/scripts/day-view.js
@@ -19,7 +19,7 @@ function displayDayTasks(key){
                 time:"-",
                 description:"<h4 class='ms-3'>No tasks for today!<h4>",
             }
-            taskDesc = makeDescriptionHTML(task, taskDesc);
+            taskDesc = makeDescriptionHTML(task, taskDesc,false);
             document.getElementById("toast-container-today").innerHTML =taskDesc;
         }
 
@@ -48,7 +48,7 @@ function displayNextTasks(key){
                 time:"-",
                 description:"<h4 class='ms-3'>No upcoming tasks!<h4>",
             }
-            taskDesc = makeDescriptionHTML(task, taskDesc);
+            taskDesc = makeDescriptionHTML(task, taskDesc, false);
             document.getElementById("toast-container-upcoming").innerHTML =taskDesc;
         }
     });

--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -26,8 +26,12 @@ function sendDataToModal(id,desc,date,time,important,completed){
 }
 
 //Function to display tasks in a box view
-function makeDescriptionHTML(task, taskDesc){
-  taskDesc += `<div class="toast show mb-3 mt-3 mx-3" role="alert" aria-live="assertive" aria-atomic="true" style="cursor:pointer" onclick="sendDataToModal('${task.id}','${task.description}','${task.date}','${task.time}','${task.important}','${task.completed}')" data-bs-toggle="modal" data-bs-target="#edit_task_modal">`;
+function makeDescriptionHTML(task, taskDesc, isATask=true){
+  taskDesc += `<div class="toast show mb-3 mt-3 mx-3" role="alert" aria-live="assertive" aria-atomic="true"`;
+  if(isATask){
+    taskDesc += ` style="cursor:pointer" onclick="sendDataToModal('${task.id}','${task.description}','${task.date}','${task.time}','${task.important}','${task.completed}')" data-bs-toggle="modal" data-bs-target="#edit_task_modal"`;
+  }
+  taskDesc += `>`;
       taskDesc += `<div class="toast-header justify-content-between">`;
           taskDesc += (task.important) ? `<strong><i class="bi bi-brightness-high-fill" style="color:red"></i></strong>` : `<span></span>`
           taskDesc += `<span class="fs-6">${task.date} | ${task.time}</span>`;

--- a/static/scripts/script.js
+++ b/static/scripts/script.js
@@ -27,9 +27,11 @@ function sendDataToModal(id,desc,date,time,important,completed){
 
 //Function to display tasks in a box view
 function makeDescriptionHTML(task, taskDesc, isATask=true){
-  taskDesc += `<div class="toast show mb-3 mt-3 mx-3" role="alert" aria-live="assertive" aria-atomic="true"`;
+  taskDesc += `<div class="toast show mb-3 mt-3 mx-3" role="alert" aria-live="assertive" aria-atomic="true" style="cursor:pointer"`;
   if(isATask){
-    taskDesc += ` style="cursor:pointer" onclick="sendDataToModal('${task.id}','${task.description}','${task.date}','${task.time}','${task.important}','${task.completed}')" data-bs-toggle="modal" data-bs-target="#edit_task_modal"`;
+    taskDesc += ` onclick="sendDataToModal('${task.id}','${task.description}','${task.date}','${task.time}','${task.important}','${task.completed}')" data-bs-toggle="modal" data-bs-target="#edit_task_modal"`;
+  }else{
+    taskDesc += ` data-bs-toggle="modal" data-bs-target="#staticBackdrop"`;
   }
   taskDesc += `>`;
       taskDesc += `<div class="toast-header justify-content-between">`;

--- a/static/scripts/week-view.js
+++ b/static/scripts/week-view.js
@@ -72,7 +72,7 @@ function displayWeeklyTasks(key){
                 time:"-",
                 description:"<h4 class='ms-3'>No tasks for today!<h4>",
             }
-            taskDesc = makeDescriptionHTML(task, taskDesc);
+            taskDesc = makeDescriptionHTML(task, taskDesc,false);
             document.getElementById(key).innerHTML =taskDesc;
         }
     });

--- a/static/styles/add_task.css
+++ b/static/styles/add_task.css
@@ -1,0 +1,30 @@
+@keyframes shake {
+  10%, 90% {
+    transform: translate3d(-1px, 0, 0);
+  }
+  
+  20%, 80% {
+    transform: translate3d(2px, 0, 0);
+  }
+
+  30%, 50%, 70% {
+    transform: translate3d(-4px, 0, 0);
+  }
+
+  40%, 60% {
+    transform: translate3d(4px, 0, 0);
+  }
+}
+
+.hide{
+  display: none;
+}
+
+.show{
+  display: block;
+}
+
+.shake{
+    animation: shake 0.82s cubic-bezier(.36, .07, .19, .97) both;
+    transform: translate3d(0, 0, 0);
+}

--- a/templates/add_task_button.html
+++ b/templates/add_task_button.html
@@ -1,4 +1,5 @@
 <!--This div is for the left aligned elements below the calendar-->
+<link rel="stylesheet" href="{{url_for('static', filename='styles/add_task.css')}}">
 <div class="">
     <!-- Button trigger modal -->
     <button type="button" class="btn btn-yellow" data-bs-toggle="modal" data-bs-target="#staticBackdrop">
@@ -19,9 +20,13 @@
                     <!-- output for date is MM-DD-YYYY -->
                     <form id="add-task-form" method="POST">
                         <div class="mb-3">
+                            <div class="alert alert-danger mt-2 hide" role="alert" id="add_task_alerts">
+                                
+                            </div>
+                        </div>
+                        <div class="mb-3">
                             <label class="control-label" for="date">Date</label>
-                            <input class="form-control datepicker" id="date" name="date" type="date" value=""
-                                data-date-format="mm/dd/yyyy" required />
+                            <input class="form-control datepicker" id="date" name="date" type="date" data-date-format="mm/dd/yyyy" required />
                         </div>
                         <div class="mb-3">
                             <label for="desc" class="form-label">Task</label>
@@ -62,8 +67,14 @@
         var text_field = $('#desc');
         var time_field = $('#time');
         var impo_field = ($('#important')[0].checked) ? true : false;
-        $("#close-add-task").click();
-        api_create_task({ description: text_field.val(), date: date_field.val(), time: time_field.val(), important: impo_field},
+
+        if(date_field.val() == "" || text_field.val() == "" || time_field.val() == ""){
+            $("#add_task_alerts").html("Cannot have empty fields");
+            $("#add_task_alerts").removeClass("hide");
+            $("#staticBackdrop").addClass("shake");
+
+        }else{
+            api_create_task({ description: text_field.val(), date: date_field.val(), time: time_field.val(), important: impo_field},
             // for the success function, instead of console log, just redirect user to whatever page they are currently on (excluding the GET variables)
             function (result) {
                 // this function turns https://www.test.com?id=123&name=abc into https://www.test.com only because that is what the redirect function is expecting
@@ -71,5 +82,12 @@
                 let urlToSendTo = window.location.href.split("?")[0];
                 window.location.replace(urlToSendTo);
             });
+        }
     });
+
+    $("#close-add-task").on('click', function () {
+        $("#staticBackdrop").removeClass("shake");
+        $("#add_task_alerts").addClass("hide");
+    });
+
 </script>

--- a/templates/add_task_button.html
+++ b/templates/add_task_button.html
@@ -15,39 +15,34 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <!-- let user input date and data for the task -->
-                    <!-- the form body to insert the task with date and content -->
-                    <!-- output for date is MM-DD-YYYY -->
-                    <form id="add-task-form" method="POST">
-                        <div class="mb-3">
-                            <div class="alert alert-danger mt-2 hide" role="alert" id="add_task_alerts">
-                                
-                            </div>
+                    <div class="mb-3">
+                        <div class="alert alert-danger mt-2 hide" role="alert" id="add_task_alerts">
+                            
                         </div>
-                        <div class="mb-3">
-                            <label class="control-label" for="date">Date</label>
-                            <input class="form-control datepicker" id="date" name="date" type="date" data-date-format="mm/dd/yyyy" required />
-                        </div>
-                        <div class="mb-3">
-                            <label for="desc" class="form-label">Task</label>
-                            <textarea class="form-control" id="desc" rows="2" name="description"
-                                required></textarea>
-                        </div>
-                        <div class="mb-3">
-                            <label for="time" class="form-label">Time</label>
-                            <input class="form-control" id="time" name="time" type="time" required></input>
-                        </div>
-                        <div class="mb-3 form-check">
-                            <input class="form-check-input" type="checkbox" id="important" value="1" name="important">
-                            <label class="form-check-label" for="mark_important" id="label_for_add_important">
-                                Mark as Important
-                            </label>
-                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="control-label" for="date">Date</label>
+                        <input class="form-control datepicker" id="date" name="date" type="date" data-date-format="mm/dd/yyyy" required />
+                    </div>
+                    <div class="mb-3">
+                        <label for="desc" class="form-label">Task</label>
+                        <textarea class="form-control" id="desc" rows="2" name="description"
+                            required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="time" class="form-label">Time</label>
+                        <input class="form-control" id="time" name="time" type="time" required></input>
+                    </div>
+                    <div class="mb-3 form-check">
+                        <input class="form-check-input" type="checkbox" id="important" value="1" name="important">
+                        <label class="form-check-label" for="mark_important" id="label_for_add_important">
+                            Mark as Important
+                        </label>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <!-- don't click submit for now -->
-                    <button type="submit" class="btn btn-outline-primary" id="add-task">Add Task</button>
-                    </form>
+                    <button type="button" class="btn btn-outline-primary" id="add-task">Add Task</button>
                     <button type="button" id="close-add-task" class="btn btn-outline-danger"
                         data-bs-dismiss="modal">Close</button>
                 </div>
@@ -69,7 +64,7 @@
         var impo_field = ($('#important')[0].checked) ? true : false;
 
         if(date_field.val() == "" || text_field.val() == "" || time_field.val() == ""){
-            $("#add_task_alerts").html("Cannot have empty fields");
+            $("#add_task_alerts").html("Cannot have empty fields!!!");
             $("#add_task_alerts").removeClass("hide");
             $("#staticBackdrop").addClass("shake");
 

--- a/templates/add_task_button.html
+++ b/templates/add_task_button.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="{{url_for('static', filename='styles/add_task.css')}}">
 <div class="">
     <!-- Button trigger modal -->
-    <button type="button" class="btn btn-yellow" data-bs-toggle="modal" data-bs-target="#staticBackdrop">
+    <button type="button" id="add-task-button" class="btn btn-yellow" data-bs-toggle="modal" data-bs-target="#staticBackdrop">
         Add Task <i class="bi bi-plus-circle"></i>
     </button>
     <!-- Modal -->

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -70,7 +70,8 @@
     </div>
     
 </div>
-
+{% include 'add_task_button.html' %}
+{% include 'edit_task_modal.html' %}
 <!--link to script-->
 <script src="{{url_for('static', filename='scripts/dashboard.js')}}"></script>
 

--- a/templates/edit_task_modal.html
+++ b/templates/edit_task_modal.html
@@ -1,4 +1,5 @@
 <!-- Modal -->
+<link rel="stylesheet" href="{{url_for('static', filename='styles/add_task.css')}}">
     <div class="modal fade" id="edit_task_modal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1"
         aria-labelledby="edit_task_modal_label" aria-hidden="true">
         <div class="modal-dialog">
@@ -7,37 +8,39 @@
                     <h5 class="modal-title" id="edit_task_modal_label">Edit Task</h5>
                     <button type="button" id="close_button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body">
-                    <!-- let user input date and data for the task -->
-                    <!-- the form body to insert the task with date and content -->
-                    <!-- output for date is MM-DD-YYYY -->
-                        <div class="mb-3">
-                            <label class="control-label" for="date">Date</label>
-                            <input class="form-control datepicker" id="new_date" name="new_date" type="date" value=""
-                                data-date-format="mm/dd/yyyy" required />
+            <div class="modal-body">
+                    <div class="mb-3">
+                        <div class="alert alert-danger mt-2 hide" role="alert" id="update_task_alerts">
+                    
                         </div>
-                        <div class="mb-3">
-                            <label for="exampleFormControlTextarea1" class="form-label">Task</label>
-                            <textarea class="form-control" id="new_description" rows="2" name="new_description"
-                                required></textarea>
-                        </div>
-                        <div class="mb-3">
-                            <label for="time" class="form-label">Time</label>
-                            <input class="form-control" id="new_time" name="new_time" type="time" required></input>
-                        </div>
-                        <input type="hidden" name="task_id" id="task_id" />
-                        <div class="mb-3 form-check">
-                            <input class="form-check-input" type="checkbox" value="completed" id="mark_completed">
-                            <label class="form-check-label" for="mark_completed" id="label_for_completed">
-                                Mark as Completed
-                            </label>
-                        </div>
-                        <div class="mb-3 form-check">
-                            <input class="form-check-input" type="checkbox" value="important" id="mark_important">
-                            <label class="form-check-label" for="mark_important" id="label_for_important">
-                                Mark as Important
-                            </label>
-                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <label class="control-label" for="date">Date</label>
+                        <input class="form-control datepicker" id="new_date" name="new_date" type="date" value=""
+                            data-date-format="mm/dd/yyyy" required />
+                    </div>
+                    <div class="mb-3">
+                        <label for="exampleFormControlTextarea1" class="form-label">Task</label>
+                        <textarea class="form-control" id="new_description" rows="2" name="new_description"
+                            required></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="time" class="form-label">Time</label>
+                        <input class="form-control" id="new_time" name="new_time" type="time" required></input>
+                    </div>
+                    <input type="hidden" name="task_id" id="task_id" />
+                    <div class="mb-3 form-check">
+                        <input class="form-check-input" type="checkbox" value="completed" id="mark_completed">
+                        <label class="form-check-label" for="mark_completed" id="label_for_completed">
+                            Mark as Completed
+                        </label>
+                    </div>
+                    <div class="mb-3 form-check">
+                        <input class="form-check-input" type="checkbox" value="important" id="mark_important">
+                        <label class="form-check-label" for="mark_important" id="label_for_important">
+                            Mark as Important
+                        </label>
+                    </div>
                 </div>
                 <div class="modal-footer d-flex justify-content-between">
                     <!-- don't click submit for now -->
@@ -60,6 +63,12 @@
         let new_time = $("#new_time").val();
         let mark_important = $("#mark_important")[0].checked;
         let mark_completed = $("#mark_completed")[0].checked;
+
+        if (new_description == "") {
+            $("#update_task_alerts").html("Cannot have empty fields");
+            $("#update_task_alerts").removeClass("hide");
+            $("#edit_task_modal").addClass("shake");
+        }
 
         // send ajax request to update the task
         // create the task object first

--- a/templates/edit_task_modal.html
+++ b/templates/edit_task_modal.html
@@ -65,7 +65,7 @@
         let mark_completed = $("#mark_completed")[0].checked;
 
         if (new_description == "") {
-            $("#update_task_alerts").html("Cannot have empty fields");
+            $("#update_task_alerts").html("Cannot have empty fields!!!");
             $("#update_task_alerts").removeClass("hide");
             $("#edit_task_modal").addClass("shake");
         }

--- a/templates/login.html
+++ b/templates/login.html
@@ -22,12 +22,12 @@
                     <form action="/login" method="POST">
                         <div class="my-3">
                             <label for="exampleInputEmail1" class="form-label">Email address</label>
-                            <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" name="user_email" required>
+                            <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" name="user_email" value="{{email}}" required>
                             <div id="emailHelp" class="form-text">We'll never share your email with anyone else.</div>
                         </div>
                         <div class="mb-3">
                             <label for="exampleInputPassword1" class="form-label">Password</label>
-                            <input type="password" class="form-control" id="exampleInputPassword1" name="user_password" required>
+                            <input type="password" class="form-control" id="exampleInputPassword1" name="user_password" value="{{password}}" required>
                         </div>
                         <button type="submit" class="btn btn-blue">Submit</button>
                     </form>

--- a/templates/register.html
+++ b/templates/register.html
@@ -21,28 +21,25 @@
                     <form action="/register" method="POST">
                         <div class="my-3">
                             <label for="exampleInputEmail1" class="form-label">Email address</label>
-                            <input type="email" class="form-control" id="exampleInputEmail1"
-                                aria-describedby="emailHelp" name="user_email" required>
+                            <input type="email" class="form-control" id="exampleInputEmail1" value="{{email}}" aria-describedby="emailHelp" name="user_email" required>
                             <div id="emailHelp" class="form-text">We'll never share your email with anyone else.</div>
                         </div>
                         <div class="mb-3">
                             <label for="exampleInputPassword1" class="form-label">Password</label>
-                            <input type="password" class="form-control" id="exampleInputPassword1" name="user_password"
-                                required>
+                            <input type="password" class="form-control" id="exampleInputPassword1" name="user_password" value="{{password1}}" required>
                             <div id="emailHelp" class="form-text">Password must be at least 8 characters long</div>
                         </div>
                         <div class="mb-3">
                             <label for="exampleInputPassword2" class="form-label">Confirm Password</label>
-                            <input type="password" class="form-control" id="exampleInputPassword2"
-                                name="confirm_password" required>
+                            <input type="password" class="form-control" id="exampleInputPassword2" value="{{password2}}" name="confirm_password" required>
                         </div>
                         <div class="mb-3">
                             <label for="security_question" class="form-label">Security Question (Create your own)</label>
-                            <input type="text" class="form-control" id="security_question" name="security_question" required>
+                            <input type="text" class="form-control" id="security_question" name="security_question" value="{{security_question}}" required>
                         </div>
                         <div class="mb-3">
                             <label for="security_answer" class="form-label"> Answer</label>
-                            <input type="password" class="form-control" id="security_answer" name="security_answer" required>
+                            <input type="password" class="form-control" id="security_answer" name="security_answer" value="{{security_answer}}" required>
                         </div>
                         <button type="submit" class="btn btn-blue" id="signup_user" name="signup_user">Submit</button>
                     </form>

--- a/templates/weekly.html
+++ b/templates/weekly.html
@@ -38,6 +38,7 @@
     </div>
   </div>
 </div>
+{% include 'edit_task_modal.html' %}
 
 <!-- Individual page stylesheet and script -->
 <link rel="stylesheet" href="{{url_for('static', filename='styles/weekly.css')}}">


### PR DESCRIPTION
- [x] User cannot add a task without a date or with an empty description or time field
- [x] Clicking on the "No tasks for today!" won't bring up the modal anymore
- [x] If signup or login fails for any reason, the data will still persist so that the user won't have to type in everything again! (per yesterday's UX feedback)
- [x] There is a little bit of shake animation if an empty field is provided in the modal to add a task or update a task. This is just for better UX  
- [x] User can now add a task from the weekly view if they click on the "No tasks today" toast
- [x] User can also edit a task from weekly view
- [x] User can add and edit a task from the dashboard as well   